### PR TITLE
Added sudo support and SHA download verification

### DIFF
--- a/exodus-installer-eden.sh
+++ b/exodus-installer-eden.sh
@@ -1,0 +1,1 @@
+exodus-installer.sh

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -79,7 +79,7 @@ exodus_is_installed() {
 exodus_uninstall() {
   # remove app files
   rm -f  /usr/bin/Exodus${EDEN_BIN_SUFFIX}
-  rm -rf /opt/exodus
+  rm -rf /opt/exodus${EDEN_DOWNLOAD_INFIX}
   rm -f  /usr/share/applications/Exodus${EDEN_BIN_SUFFIX}.desktop
   find /usr/share/icons/hicolor/ -type f -name *Exodus.png -delete
 

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -143,7 +143,7 @@ EOF
       fi
 
       if exodus_is_installed; then
-        >&2 echo 'Exodus already installed.'
+        >&2 echo 'Exodus'${EDEN_BIN_SUFFIX}' already installed.'
         return 1
       fi
 

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -39,7 +39,8 @@ exodus_download_url() {
 # Generate the download target on disk
 #
 exodus_download_target() {
-  echo $HOME'/Downloads/'$1
+  mkdir -p $HOME/Downloads
+  echo $HOME'/Downloads/exodus_linux_'$1'.zip'
 }
 
 
@@ -78,9 +79,9 @@ exodus_is_installed() {
 #
 exodus_uninstall() {
   # remove app files
-  rm -f  /usr/bin/Exodus${EDEN_BIN_SUFFIX}
-  rm -rf /opt/exodus${EDEN_DOWNLOAD_INFIX}
-  rm -f  /usr/share/applications/Exodus${EDEN_BIN_SUFFIX}.desktop
+  rm -f /usr/bin/Exodus
+  rm -rf /opt/exodus
+  rm -f /usr/share/applications/Exodus.desktop
   find /usr/share/icons/hicolor/ -type f -name *Exodus.png -delete
 
   # drop exodus://
@@ -116,7 +117,7 @@ exodus_installer() {
   COMMAND=$1
   shift
 
-  case $COMMAND in 
+  case $COMMAND in
     'help' | '--help' )
       cat << EOF
 
@@ -210,5 +211,3 @@ EOF
 # pass arguments to main function
 #
 exodus_installer $@
-
-# vim: ts=4 sw=2

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 
 # https://www.gnu.org/software/bash/manual/bash.html
-INSTALLER_VERSION=1.0.2
+INSTALLER_VERSION=1.0.3
 
 exodus_download_url() {
-  echo 'https://dl.dropboxusercontent.com/u/173974/exodus/release/exodus_linux_'$1'.tar.xz'
+  echo 'https://exodusbin.azureedge.net/releases/exodus-linux-x64-'$1'.zip'
 }
 
 exodus_download_target() {
-  echo $HOME'/Downloads/exodus_linux_'$1'.tar.xz'
+  echo $HOME'/Downloads/exodus_linux_'$1'.zip'
 }
 
 exodus_download() {
-  if [ -e $2 ]; then
+  if [ -e $2 ];
+  then
     echo $2' already exists, overwrite it?'
     select yn in 'Yes' 'No'; do
       case $yn in
         'Yes' )
-          wget -v -o $2 $1
+          wget -v -O $2 $1
           break
         ;;
         'No' )
@@ -25,12 +26,16 @@ exodus_download() {
         ;;
       esac
     done
+  else
+	wget -v -O $2 $1
   fi 
 }
 
 exodus_install() {
   # extract files & create link
-  xz -dkfc $1 | tar -x -C /
+  #xz -dkfc $1 | tar -x -C /
+  unzip -d /opt/ $1
+  mv /opt/Exodus-linux-* /opt/exodus
   ln -s -f /opt/exodus/Exodus /usr/bin/Exodus
 
   # register exodus://
@@ -46,9 +51,9 @@ exodus_is_installed() {
 
 exodus_uninstall() {
   # remove app files
-  rm -f /usr/bin/Exodus
+  rm -f  /usr/bin/Exodus
   rm -rf /opt/exodus
-  rm -f /usr/share/applications/Exodus.desktop
+  rm -f  /usr/share/applications/Exodus.desktop
   find /usr/share/icons/hicolor/ -type f -name *Exodus.png -delete
 
   # drop exodus://
@@ -83,8 +88,8 @@ Usage:
 
 Example:
 
-  $0 install ~/Downloads/exodus_linux_1.4.0.tar.xz   Install Exodus 1.4.0 from file
-  $0 install 1.4.0                                   Download and install Exodus 1.4.0
+  $0 install ~/Downloads/exodus_linux_1.4.0.zip   Install Exodus 1.4.0 from file
+  $0 install 1.4.0                                Download and install Exodus 1.4.0
 
 EOF
     ;;
@@ -108,7 +113,7 @@ EOF
         exodus_download `exodus_download_url $1` $EXODUS_PKG
       fi
 
-      xz -t $EXODUS_PKG
+      unzip -t $EXODUS_PKG
       if [ $? -ne 0 ]; then
         return 1
       fi
@@ -159,3 +164,5 @@ EOF
 
 # pass arguments to main function
 exodus_installer $@
+
+# vim: ts=4 sw=2

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -80,7 +80,7 @@ exodus_is_installed() {
 exodus_uninstall() {
   # remove app files
   rm -f /usr/bin/Exodus${EDEN_BIN_SUFFIX}
-  rm -rf /opt/exodus
+  rm -rf /opt/exodus${EDEN_DOWNLOAD_INFIX}
   rm -f /usr/share/applications/Exodus${EDEN_BIN_SUFFIX}.desktop
   find /usr/share/icons/hicolor/ -type f -name *Exodus.png -delete
 

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -40,7 +40,7 @@ exodus_download_url() {
 #
 exodus_download_target() {
   mkdir -p $HOME/Downloads
-  echo $HOME'/Downloads/exodus_linux_'$1'.zip'
+  echo $HOME'/Downloads/'$1
 }
 
 
@@ -79,9 +79,9 @@ exodus_is_installed() {
 #
 exodus_uninstall() {
   # remove app files
-  rm -f /usr/bin/Exodus
+  rm -f /usr/bin/Exodus${EDEN_BIN_SUFFIX}
   rm -rf /opt/exodus
-  rm -f /usr/share/applications/Exodus.desktop
+  rm -f /usr/share/applications/Exodus${EDEN_BIN_SUFFIX}.desktop
   find /usr/share/icons/hicolor/ -type f -name *Exodus.png -delete
 
   # drop exodus://
@@ -148,15 +148,18 @@ EOF
         return 1
       fi
 
-      local EXODUS_PKG
+	  local EXODUS_PKG
       if [[ $# -eq 1 && -f $1 ]]; then
         EXODUS_PKG=$1
       else
-        local EXODUS_FILENAME=`exodus_filename $1`
-        EXODUS_PKG=`exodus_download_target ${EXODUS_FILENAME}`
-        local EXODUS_URL=`exodus_download_url ${EXODUS_FILENAME}`
-        exodus_download $EXODUS_URL $EXODUS_PKG
-      fi
+		local EXODUS_FILENAME=`exodus_filename $1`
+		EXODUS_PKG=`exodus_download_target ${EXODUS_FILENAME}`
+		local EXODUS_URL=`exodus_download_url ${EXODUS_FILENAME}`
+		exodus_download $EXODUS_URL $EXODUS_PKG
+        if [ $? -ne 0 ]; then
+          return 1
+        fi
+	  fi
 
       if ! unzip -t $EXODUS_PKG > /dev/null; then
         echo "$EXODUS_PKG is a corrupt file! Please remove and redownload!"

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -58,7 +58,7 @@ exodus_download() {
 
 
 # Download and check the exodus package to verify
-# SHA hash
+# SHA hash. Shamelessly stolen from https://github.com/kklash/exodus_tools
 exodus_verify_hashes() {
   #
   # If JP's key doesn't exist...
@@ -184,18 +184,17 @@ EOF
         return 1
       fi
 
-	  local EXODUS_PKG
+      local EXODUS_PKG
       if [[ $# -eq 1 && -f $1 ]]; then
         EXODUS_PKG=$1
       else
-		local EXODUS_FILENAME=`exodus_filename $1`
-		EXODUS_PKG=`exodus_download_target ${EXODUS_FILENAME}`
-		local EXODUS_URL=`exodus_download_url ${EXODUS_FILENAME}`
-		exodus_download $EXODUS_URL $EXODUS_PKG
-        if [ $? -ne 0 ]; then
+        local EXODUS_FILENAME=`exodus_filename $1`
+        EXODUS_PKG=`exodus_download_target ${EXODUS_FILENAME}`
+        local EXODUS_URL=`exodus_download_url ${EXODUS_FILENAME}`
+        if ! exodus_download $EXODUS_URL $EXODUS_PKG; then
           return 1
         fi
-	  fi
+      fi
 
       if ! exodus_verify_hashes $1 $EXODUS_PKG; then
         echo "$EXODUS_PKG has failed the hashing checksum! Aborting installation!"
@@ -216,11 +215,10 @@ EOF
         return 127
       fi
 
-      exodus_is_installed
-      if [ $? -eq 1 ]; then
-        echo 'Exodus'${EDEN_BIN_SUFFIX}' is not installed.'
-      else
+      if exodus_is_installed; then
         echo 'Exodus'${EDEN_BIN_SUFFIX}' is installed. Version: '`Exodus${EDEN_BIN_SUFFIX} --version`
+      else
+        echo 'Exodus'${EDEN_BIN_SUFFIX}' is not installed.'
       fi
     ;;
     'uninstall' )

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -137,7 +137,7 @@ Example:
 EOF
     ;;
     'install' | 'i' )
-	  if [ $# -ne 1 ]; then
+      if [ $# -ne 1 ]; then
         >&2 $0 --help
         return 127
       fi
@@ -147,18 +147,18 @@ EOF
         return 1
       fi
 
-	  local EXODUS_PKG
+      local EXODUS_PKG
       if [[ $# -eq 1 && -f $1 ]]; then
         EXODUS_PKG=$1
       else
-		local EXODUS_FILENAME=`exodus_filename $1`
-		EXODUS_PKG=`exodus_download_target ${EXODUS_FILENAME}`
-		local EXODUS_URL=`exodus_download_url ${EXODUS_FILENAME}`
-		exodus_download $EXODUS_URL $EXODUS_PKG
-	  fi
+        local EXODUS_FILENAME=`exodus_filename $1`
+        EXODUS_PKG=`exodus_download_target ${EXODUS_FILENAME}`
+        local EXODUS_URL=`exodus_download_url ${EXODUS_FILENAME}`
+        exodus_download $EXODUS_URL $EXODUS_PKG
+      fi
 
       if ! unzip -t $EXODUS_PKG > /dev/null; then
-      	echo "$EXODUS_PKG is a corrupt file! Please remove and redownload!"
+        echo "$EXODUS_PKG is a corrupt file! Please remove and redownload!"
         return 1
       fi
 

--- a/exodus-installer.sh
+++ b/exodus-installer.sh
@@ -1,42 +1,63 @@
 #!/usr/bin/env bash
-
+#
+# Open source, released under the MIT license (see LICENSE file).
+#
 # https://www.gnu.org/software/bash/manual/bash.html
-INSTALLER_VERSION=1.0.3
+#
+# Link this file so that `-eden` appears in the name, and the Eden version
+# will be installed.
+#
 
+# Global variables
+#
+INSTALLER_VERSION=1.0.4
+PROCESSOR="x64"
+#
+# Check for eden suffix in name of script. If detected, download the Eden version instead.
+#
+if [[ $0 =~ .*-eden.* ]]; then
+  EDEN_DOWNLOAD_INFIX=-eden
+  EDEN_BIN_SUFFIX=Eden
+fi
+
+
+# Generate a base file name, with eden infix, processor and version.
+#
+exodus_filename() {
+  echo 'exodus'${EDEN_DOWNLOAD_INFIX}'-linux-'${PROCESSOR}'-'$1'.zip'
+}
+
+
+# Generate the download URL
+# This can change, so we have to make sure this is "up to date"
+#
 exodus_download_url() {
-  echo 'https://exodusbin.azureedge.net/releases/exodus-linux-x64-'$1'.zip'
+  echo 'https://exodusbin.azureedge.net/releases/'$1
 }
 
+
+# Generate the download target on disk
+#
 exodus_download_target() {
-  echo $HOME'/Downloads/exodus_linux_'$1'.zip'
+  echo $HOME'/Downloads/'$1
 }
 
+
+# Download the Exodus payload from the server, but only
+# download if we don't have it on disk already (-c option)
+#
 exodus_download() {
-  if [ -e $2 ];
-  then
-    echo $2' already exists, overwrite it?'
-    select yn in 'Yes' 'No'; do
-      case $yn in
-        'Yes' )
-          wget -v -O $2 $1
-          break
-        ;;
-        'No' )
-          break
-        ;;
-      esac
-    done
-  else
-	wget -v -O $2 $1
-  fi 
+  wget -v -c -O $2 $1
 }
 
+
+# Install the exodus package to the /opt folder
+#
 exodus_install() {
   # extract files & create link
-  #xz -dkfc $1 | tar -x -C /
   unzip -d /opt/ $1
-  mv /opt/Exodus-linux-* /opt/exodus
-  ln -s -f /opt/exodus/Exodus /usr/bin/Exodus
+  mv /opt/Exodus${EDEN_BIN_SUFFIX}-linux-* /opt/exodus${EDEN_DOWNLOAD_INFIX}
+  ln -s -f /opt/exodus${EDEN_DOWNLOAD_INFIX}/Exodus${EDEN_BIN_SUFFIX} /usr/bin/Exodus${EDEN_BIN_SUFFIX}
 
   # register exodus://
   update-desktop-database > /dev/null 2>&1
@@ -45,15 +66,21 @@ exodus_install() {
   gtk-update-icon-cache /usr/share/icons/hicolor -f > /dev/null 2>&1
 }
 
+
+# Check to see if Exodus is installed
+#
 exodus_is_installed() {
-  which Exodus > /dev/null 2>&1
+  which Exodus${EDEN_BIN_SUFFIX} > /dev/null 2>&1
 }
 
+
+# Uninstall the application completely
+#
 exodus_uninstall() {
   # remove app files
-  rm -f  /usr/bin/Exodus
+  rm -f  /usr/bin/Exodus${EDEN_BIN_SUFFIX}
   rm -rf /opt/exodus
-  rm -f  /usr/share/applications/Exodus.desktop
+  rm -f  /usr/share/applications/Exodus${EDEN_BIN_SUFFIX}.desktop
   find /usr/share/icons/hicolor/ -type f -name *Exodus.png -delete
 
   # drop exodus://
@@ -63,6 +90,22 @@ exodus_uninstall() {
   gtk-update-icon-cache /usr/share/icons/hicolor -f > /dev/null 2>&1
 }
 
+
+# Do the actual installation procedure, calling the above functions when needed.
+#
+# This function detects the command line arguments and verifies they are correct.
+# Then each case is run according to the arguments. What this does is:
+#
+# 1) download the version specified from Exodus' servers (if version specified
+#                                                         otherwise, use supplied filename)
+# 2) check the integrity of the archive
+# 3) check for root privileges (use sudo)
+# 4) install the app
+#
+# Or, we can uninstall the app from the harddrive (root privs needed)
+#
+# Or, we can check to see if Exodus is installed.
+#
 exodus_installer() {
   if [ $# -lt 1 ]; then
     $0 --help
@@ -94,27 +137,28 @@ Example:
 EOF
     ;;
     'install' | 'i' )
-      if [ $# -ne 1 ]; then
+	  if [ $# -ne 1 ]; then
         >&2 $0 --help
         return 127
       fi
 
-      exodus_is_installed
-      if [ $? -eq 0 ]; then
+      if exodus_is_installed; then
         >&2 echo 'Exodus already installed.'
         return 1
       fi
 
-      local EXODUS_PKG
+	  local EXODUS_PKG
       if [[ $# -eq 1 && -f $1 ]]; then
         EXODUS_PKG=$1
       else
-        EXODUS_PKG=`exodus_download_target $1`
-        exodus_download `exodus_download_url $1` $EXODUS_PKG
-      fi
+		local EXODUS_FILENAME=`exodus_filename $1`
+		EXODUS_PKG=`exodus_download_target ${EXODUS_FILENAME}`
+		local EXODUS_URL=`exodus_download_url ${EXODUS_FILENAME}`
+		exodus_download $EXODUS_URL $EXODUS_PKG
+	  fi
 
-      unzip -t $EXODUS_PKG
-      if [ $? -ne 0 ]; then
+      if ! unzip -t $EXODUS_PKG > /dev/null; then
+      	echo "$EXODUS_PKG is a corrupt file! Please remove and redownload!"
         return 1
       fi
 
@@ -135,9 +179,9 @@ EOF
 
       exodus_is_installed
       if [ $? -eq 1 ]; then
-        echo 'Exodus is not installed.'
+        echo 'Exodus'${EDEN_BIN_SUFFIX}' is not installed.'
       else
-        echo 'Exodus is installed. Version: '`Exodus --version`
+        echo 'Exodus'${EDEN_BIN_SUFFIX}' is installed. Version: '`Exodus${EDEN_BIN_SUFFIX} --version`
       fi
     ;;
     'uninstall' )
@@ -162,7 +206,9 @@ EOF
   esac
 }
 
+
 # pass arguments to main function
+#
 exodus_installer $@
 
 # vim: ts=4 sw=2


### PR DESCRIPTION
I cannibalized Konnor's `verifyLinux.sh` script and put the guts into this
script. Now both Exodus and Eden have their download files checksummed
first. On failure, the script aborts.

I added sudo support in case of non-privileged user. This is because it
downloads stuff into the user's folder as owned by root, and also
attempts to import JP's GPG key, which causes a warning from GPG because
the key repo is not owned by root.