### PR TITLE
Fix ERROR 404: Not Found

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Script for downloading/installing/uninstalling [Exodus][1] on Linux.
 # chmod +x /usr/bin/exodus-installer
 $ exodus-installer check
 Exodus is not installed.
-# exodus-installer install 1.4.0
+# exodus-installer install 1.40.0
 $ exodus-installer check
-Exodus is installed. Version: 1.4.0
+Exodus is installed. Version: 1.40.0
 # exodus-installer uninstall
 ```
 


### PR DESCRIPTION
Fix version number to 1.40.0 at README in order to match with the download url
https://exodusbin.azureedge.net/releases/exodus-linux-x64-1.40.0.zip